### PR TITLE
Fix overflowing code issue

### DIFF
--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -2,7 +2,8 @@ code {
   background: #eee;
   font-size: 16px;
   padding: .25rem .5rem;
-  white-space: nowrap;
+  white-space: normal;
+  word-wrap:break-word;
   margin-right: .5rem;
 }
 

--- a/css/i.css
+++ b/css/i.css
@@ -8058,7 +8058,7 @@ a {
 
   .mn-wi-fill-l {
     min-width: fill-available; } }
-/* normalize.css v2.1.2 | MIT License | git.io/normalize */
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ==========================================================================
    HTML5 display definitions
    ========================================================================== */
@@ -9924,28 +9924,28 @@ table {
   color: gainsboro; }
 
 .lightgray {
-  color: lightgrey; }
+  color: lightgray; }
 
 .silver {
   color: silver; }
 
 .darkgray {
-  color: darkgrey; }
+  color: darkgray; }
 
 .gray {
   color: gray; }
 
 .dimgray {
-  color: dimgrey; }
+  color: dimgray; }
 
 .lightslategray {
-  color: lightslategrey; }
+  color: lightslategray; }
 
 .slategray {
-  color: slategrey; }
+  color: slategray; }
 
 .darkslategray {
-  color: darkslategrey; }
+  color: darkslategray; }
 
 .black {
   color: black; }
@@ -10345,28 +10345,28 @@ table {
   background-color: gainsboro; }
 
 .bg-lightgray {
-  background-color: lightgrey; }
+  background-color: lightgray; }
 
 .bg-silver {
   background-color: silver; }
 
 .bg-darkgray {
-  background-color: darkgrey; }
+  background-color: darkgray; }
 
 .bg-gray {
   background-color: gray; }
 
 .bg-dimgray {
-  background-color: dimgrey; }
+  background-color: dimgray; }
 
 .bg-lightslategray {
-  background-color: lightslategrey; }
+  background-color: lightslategray; }
 
 .bg-slategray {
-  background-color: slategrey; }
+  background-color: slategray; }
 
 .bg-darkslategray {
-  background-color: darkslategrey; }
+  background-color: darkslategray; }
 
 .bg-black {
   background-color: black; }
@@ -14430,7 +14430,8 @@ code {
   background: #eee;
   font-size: 16px;
   padding: .25rem .5rem;
-  white-space: nowrap;
+  white-space: normal;
+  word-wrap: break-word;
   margin-right: .5rem; }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Fixes overflowing code issue, which made the vertical scroll on mobile go left to right like crazy.

Also, the header looked like this: 
![screenshot 2013-12-26 08 31 04](https://f.cloud.github.com/assets/3824954/1810735/ce695d84-6e33-11e3-8eb5-f99443414bae.png)

The diff in css/i.css is just a recompile of the sass, which was done by:

```
$ sass i.scss:../css/i.css
```
