### PR TITLE
Improve reability of the number zero

### DIFF
--- a/_posts/2016-04-21-developing-ui.html
+++ b/_posts/2016-04-21-developing-ui.html
@@ -7,7 +7,7 @@ layout: post
 
 <p>The single hardest part of front-end development at any scale is making changes to code and understanding all of the resulting visual and behavioral effects that will occur across the application.</p>
 
-<p>Several years ago I worked on a print and email product where our main directive was to ship 0 bugs. While simultaneously shipping features as quickly as possible. On the web 'mean time to fix failure' is generally more valuable than 'mean time between failure.' This makes sense. Often times you can fix a bug on a website before many people will see it. In the world of print and email though you only get one chance. You can’t unmail an electronic or print document. The ability to work quickly without creating errors or bugs is critical.</p>
+<p>Several years ago I worked on a print and email product where our main directive was to ship zero bugs. While simultaneously shipping features as quickly as possible. On the web 'mean time to fix failure' is generally more valuable than 'mean time between failure.' This makes sense. Often times you can fix a bug on a website before many people will see it. In the world of print and email though you only get one chance. You can’t unmail an electronic or print document. The ability to work quickly without creating errors or bugs is critical.</p>
 
 
 <p>Over 3.5 years I ended up shipping two small prose based errors to production. One was caught before we mailed it, one was not. Instead of saying “Track your progress” the text said “Rack your progress.” Not perfect, but definitely better than my record on the web.</p>


### PR DESCRIPTION
While reading this on the actual blog, I was really curious what "ship O bugs" meant, and assumed it was a typo for "ship'o bugs", which confused me further. Changing the number to the word zero might help reduce future confusion.